### PR TITLE
Some CSS love and semantic fixes

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,16 +29,22 @@ if($DEBUG) {
     	body {background-color: #62a7c6; 
     		line-height:100%
     		}
-		textarea {font-size: 110%; }
-    	button {color: white; font-size: larger;}
+	textarea {font-size: 110%; 
+		padding: 0.3em;
+		}
+	button {color: white; 
+		font-size: larger;
+		padding: 0 0.4em;
+		border-radius: 5px;}
 		button:disabled,button[disabled]{
   			border: 1px solid #999999;
   			background-color: #cccccc;
   			color: #666666;
 			border-radius: 5px;
 		}
-	#reloadbutton {font-size: smaller; }
+	#reloadbutton {/* font-size: smaller; */}
 	.line { margin-top: 0.5em; }
+	.lm { margin-left: 1em; }
     </style>
 
   </head>
@@ -63,15 +69,16 @@ if(
 	onclick="sendcommand('newrec',this)">Start new</button>
 </p>
 
-<h3>Sessions
+<h3>Sessions</h3>
+<div class="filelist">
 <button type="button" id="reloadbutton" 
         style="background-color: navy"
         onclick="sendcommand('listrec', this)">Refresh list</button>
-<span>Free: </span><span id="freespace">-</span>
-</h3>
-<p>
+<span class="lm">Free: </span><span id="freespace">-</span>
+</div>
+<div class="line">
 <textarea id="log" cols="40" rows="12"></textarea>
-</p>
+</div>
 <h3>Finish</h3>
 <p>
 <div class="line">
@@ -93,9 +100,10 @@ if(
         onclick="sendcommand('cleanzip',this)">Delete ZIPs</button>
 
 </div>
-<p><a href="download.php?what=all">Zipped everything</a> 
-<a href="download.php?what=today">Today's zip</a>  
-</p>
+<h3>Download</h3>
+<div><a href="download.php?what=all">Zipped everything</a> 
+<a class="lm" href="download.php?what=today">Today's zip</a>  
+</div>
 
 <script>
 var endpoint="worker.php";
@@ -206,7 +214,7 @@ else {
 <form action="index.php" method="post">
 <input type="submit" name="logout" value="logout" />
 </form>
-<address>
+<address class="line">
 VDM 2020
 </address>
   </body>

--- a/index.php
+++ b/index.php
@@ -25,9 +25,9 @@ if($DEBUG) {
 
     <title>Jamulus Recording Remote</title>
     <style type="text/css">
-    	* { font-family: sans-serif;  }
+    	* { font-family: "Open Sans", sans-serif;  }
     	body {background-color: #62a7c6; 
-    		line-height:80%
+    		line-height:100%
     		}
 		textarea {font-size: 110%; }
     	button {color: white; font-size: larger;}
@@ -35,13 +35,14 @@ if($DEBUG) {
   			border: 1px solid #999999;
   			background-color: #cccccc;
   			color: #666666;
+			border-radius: 5px;
 		}
 	#reloadbutton {font-size: smaller; }
+	.line { margin-top: 0.5em; }
     </style>
 
   </head>
 <body>
-	<h2>Jamulus Recording Remote</h2>
 <?php
 print("<h1>$SERVERNAME</h1>\n");
 if(
@@ -50,7 +51,7 @@ if(
 	) {
 		$_SESSION['admin']=$ADMINPASSWORD;
 ?>
-    
+<h2>Jamulus Recording Remote</h2>
 <h3>Recording</h3>  
 <p id="recarea">
 <button type="button" id="togglebutton"
@@ -73,6 +74,7 @@ if(
 </p>
 <h3>Finish</h3>
 <p>
+<div class="line">
 <button type="button" id="compressbutton" 
 	style="background-color: navy" 
 	onclick="sendcommand('compress', this)">Zip all</button>
@@ -80,7 +82,8 @@ if(
 <button type="button" id="compressday" 
         style="background-color: navy"
         onclick="sendcommand('compressday', this)">Zip today</button>
-<br />
+</div>
+<div class="line">
 <button type="button" id="cleanbutton" title="Careful: this destroys all session files" 
 	style="background-color: navy"
 	onclick="sendcommand('cleanwav',this)">Delete WAVs</button>
@@ -89,7 +92,7 @@ if(
         style="background-color: navy"
         onclick="sendcommand('cleanzip',this)">Delete ZIPs</button>
 
-</p>
+</div>
 <p><a href="download.php?what=all">Zipped everything</a> 
 <a href="download.php?what=today">Today's zip</a>  
 </p>


### PR DESCRIPTION
I wanted to push back some changes I made to my local installation for your consideration.

- H1 must come before H2, etc. so have corrected the order of the headers
- Some headers contained other HTML elements, they should ideally only contain text
- Some CSS changes in improve padding and so on
- Change base font to Open Sans
- Round corners on buttons
- Add h3 title for the "download" section 

Here's a screenshot (mobile)

![houbsta hopto org_index php(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/69164084/111127613-509b7d00-8574-11eb-8934-41d08669fdd1.png)
